### PR TITLE
Double gate features

### DIFF
--- a/src/xbase/layout/enum.py
+++ b/src/xbase/layout/enum.py
@@ -103,8 +103,8 @@ class MOSWireType(IntEnum):
 
     @property
     def is_physical(self) -> bool:
-        return not (self is MOSWireType.G_MATCH or self is MOSWireType.DS_MATCH \
-            or self is MOSWireType.G2_MATCH)
+        return not (self is MOSWireType.G_MATCH or self is MOSWireType.DS_MATCH
+                    or self is MOSWireType.G2_MATCH)
 
 
 class MOSPortType(Enum):

--- a/src/xbase/layout/enum.py
+++ b/src/xbase/layout/enum.py
@@ -69,19 +69,42 @@ class MOSCutMode(Flag):
 
 # Note: make this IntEnum so it is sortable by ImmutableSortedDict.
 class MOSWireType(IntEnum):
+    """
+    These describe the placements of tracks above the conn_layer, relative to 
+    the conn_layer ports.
+
+    G: tracks directly over gate connection
+    G_MATCH: tracks south of gate connection to match / reduce gate parasitics
+    DS: tracks directly over drain / source connection
+    DS_GATE: track over drain/source, overlapping with gate if possible
+    DS_MATCH: tracks north of drain/source conn to match / reduce parasitics
+    G2: for double gate transistors, tracks directly over the 2nd gate
+    G2_MATCH: similar to G_MATCH for double gate transistors
+
+    For flipped transistors, G will be at the top, DS / G2 will be at the bottom.
+    For not flipped transistors, G will be at the bottom, DS / G2 will be at the top.
+
+    """
     G = 0
     G_MATCH = 1
     DS = 2
     DS_GATE = 3
     DS_MATCH = 4
+    G2 = 5
+    G2_MATCH = 6
 
     @property
     def is_gate(self) -> bool:
         return self is MOSWireType.G or self is MOSWireType.G_MATCH
 
     @property
+    def is_gate2(self) -> bool:
+        return self is MOSWireType.G2 or self is MOSWireType.G2_MATCH
+
+    @property
     def is_physical(self) -> bool:
-        return not (self is MOSWireType.G_MATCH or self is MOSWireType.DS_MATCH)
+        return not (self is MOSWireType.G_MATCH or self is MOSWireType.DS_MATCH \
+            or self is MOSWireType.G2_MATCH)
 
 
 class MOSPortType(Enum):

--- a/src/xbase/layout/mos/base.py
+++ b/src/xbase/layout/mos/base.py
@@ -162,7 +162,7 @@ class MOSBase(TemplateBase, abc.ABC):
 
     @property
     def can_draw_double_gate(self) -> bool:
-        """bool: True if you can short adjacent transistor ports using hm_layer."""
+        """bool: True if double gates are supported."""
         return self.tech_cls.can_draw_double_gate
 
     def draw_base(self, obj: Union[MOSBasePlaceInfo,
@@ -378,8 +378,9 @@ class MOSBase(TemplateBase, abc.ABC):
 
         # construct port object
         m_pin = inst.get_pin('m') if inst.has_port('m') else None
+        g_pin = inst.get_pin('g') if inst.has_port('g') else None
         g2_pin = inst.get_pin('g2') if inst.has_port('g2') else None
-        return MOSPorts(inst.get_pin('g'), inst.get_pin('d'), inst.get_pin('s'),
+        return MOSPorts(g_pin, inst.get_pin('d'), inst.get_pin('s'),
                         master.shorted_ports, m=m_pin, g2=g2_pin)
 
     def add_nand2(self, row_idx: int, col_idx: int, seg: int, *, tile_idx: int = 0, w: int = 0,

--- a/src/xbase/layout/mos/base.py
+++ b/src/xbase/layout/mos/base.py
@@ -160,6 +160,11 @@ class MOSBase(TemplateBase, abc.ABC):
         """bool: True if you can short adjacent transistor ports using hm_layer."""
         return self.tech_cls.can_short_adj_tracks(self.conn_layer)
 
+    @property
+    def can_draw_double_gate(self) -> bool:
+        """bool: True if you can short adjacent transistor ports using hm_layer."""
+        return self.tech_cls.can_draw_double_gate
+
     def draw_base(self, obj: Union[MOSBasePlaceInfo,
                                    TilePatternElement,
                                    Tuple[Union[MOSBasePlaceInfo, TilePattern,
@@ -373,8 +378,9 @@ class MOSBase(TemplateBase, abc.ABC):
 
         # construct port object
         m_pin = inst.get_pin('m') if inst.has_port('m') else None
+        g2_pin = inst.get_pin('g2') if inst.has_port('g2') else None
         return MOSPorts(inst.get_pin('g'), inst.get_pin('d'), inst.get_pin('s'),
-                        master.shorted_ports, m=m_pin)
+                        master.shorted_ports, m=m_pin, g2=g2_pin)
 
     def add_nand2(self, row_idx: int, col_idx: int, seg: int, *, tile_idx: int = 0, w: int = 0,
                   stack: int = 1, flip_lr: bool = False, export_mid: bool = False,

--- a/src/xbase/layout/mos/data.py
+++ b/src/xbase/layout/mos/data.py
@@ -234,8 +234,8 @@ class MOSRowInfo:
                           table['ds_m_conn_y'], table['ds_g_conn_y'], table['sub_conn_y'],
                           guard_ring=table.get('guard_ring', False),
                           double_gate=table.get('double_gate', False),
-                          g2_conn_y=table.get('g2_conn_y', (0,0)),
-                          g2_m_conn_y=table.get('g2_m_conn_y', (0,0)))
+                          g2_conn_y=table.get('g2_conn_y', (0, 0)),
+                          g2_m_conn_y=table.get('g2_m_conn_y', (0, 0)))
 
     @property
     def bot_conn_types(self) -> Sequence[MOSWireType]:
@@ -273,8 +273,6 @@ class MOSRowInfo:
             return MOSWireType.DS_GATE, MOSWireType.DS, MOSWireType.DS_MATCH
 
         raise RuntimeError("trying to use mid conn, when its not a double gate")
-        return []
-
 
     def get_ext_info(self, top_edge: bool) -> RowExtInfo:
         return self.top_ext_info if top_edge ^ self.flip else self.bot_ext_info

--- a/src/xbase/layout/mos/placement/compact.py
+++ b/src/xbase/layout/mos/placement/compact.py
@@ -146,7 +146,7 @@ def _place_mirror(tech_cls: MOSTech, ext_info: RowExtInfo, ycur: int, ignore_vm_
     blk_h_pitch = tech_cls.blk_h_pitch
 
     mirror_ext_w_info: ExtWidthInfo = tech_cls.get_ext_width_info(ext_info, ext_info,
-                                                    ignore_vm_sp_le=ignore_vm_sp_le)
+                                                                  ignore_vm_sp_le=ignore_vm_sp_le)
 
     ext_w_cur = ycur // blk_h_pitch
     ext_w_tot = mirror_ext_w_info.get_next_width(2 * ext_w_cur, even=True)
@@ -310,8 +310,7 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
             if mid_wg:
                 mid_wg.place_compact(hm_layer, tr_manager,
                                      pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
-                                     prev_wg=prev_wg, #top_mirror=top_mirror and is_top_row,)
-                                     ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_mid[1]))
+                                     prev_wg=prev_wg, ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_mid[1]))
                 prev_wg = mid_wg
             
             # place top wires above the middle wires
@@ -326,8 +325,7 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
             if top_wg:
                 top_wg.place_compact(hm_layer, tr_manager,
                                      pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
-                                     prev_wg=prev_wg, #top_mirror=top_mirror and is_top_row,
-                                     ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_top[1]))
+                                     prev_wg=prev_wg, ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_top[1]))
                 prev_wg = top_wg
             
             bnd_table = top_wg.get_placement_bounds(hm_layer, grid)
@@ -337,7 +335,6 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
                                                 conn_y_bnds_top[1], True)
         else:
             # place top wires
-            
             conn_y_bnds_top = [COORD_MAX, COORD_MIN]
             pcons = {}
             for wtype, conn_y in top_conn_y_table.items():

--- a/src/xbase/layout/mos/placement/compact.py
+++ b/src/xbase/layout/mos/placement/compact.py
@@ -59,7 +59,10 @@ class RowPlaceSpecs:
                  bot_conn_y_table: Mapping[MOSWireType, Tuple[int, int]],
                  top_conn_y_table: Mapping[MOSWireType, Tuple[int, int]],
                  bot_ext_info: RowExtInfo, top_ext_info: RowExtInfo,
-                 mid_conn_y_table: Optional[Mapping[MOSWireType, Tuple[int, int]]] = {}):
+                 mid_conn_y_table: Optional[Mapping[MOSWireType, Tuple[int, int]]] = None):
+        if not mid_conn_y_table:
+            mid_conn_y_table = {}
+
         # work around: this is how you set attributes for frozen data classes
         object.__setattr__(self, 'row_specs', row_specs)
         object.__setattr__(self, 'row_info', row_info)
@@ -306,9 +309,9 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
 
             if mid_wg:
                 mid_wg.place_compact(hm_layer, tr_manager,
-                                    pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
-                                    prev_wg=prev_wg, #top_mirror=top_mirror and is_top_row,)
-                                    ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_mid[1]))
+                                     pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
+                                     prev_wg=prev_wg, #top_mirror=top_mirror and is_top_row,)
+                                     ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_mid[1]))
                 prev_wg = mid_wg
             
             # place top wires above the middle wires
@@ -322,9 +325,9 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
 
             if top_wg:
                 top_wg.place_compact(hm_layer, tr_manager,
-                                    pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
-                                    prev_wg=prev_wg, #top_mirror=top_mirror and is_top_row,
-                                    ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_top[1]))
+                                     pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
+                                     prev_wg=prev_wg, #top_mirror=top_mirror and is_top_row,
+                                     ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_top[1]))
                 prev_wg = top_wg
             
             bnd_table = top_wg.get_placement_bounds(hm_layer, grid)
@@ -345,9 +348,9 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
 
             if top_wg:
                 top_wg.place_compact(hm_layer, tr_manager,
-                                    pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
-                                    prev_wg=prev_wg, top_mirror=top_mirror and is_top_row,
-                                    ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_top[1]))
+                                     pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
+                                     prev_wg=prev_wg, top_mirror=top_mirror and is_top_row,
+                                     ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_top[1]))
                 if row_info.row_type.is_substrate:
                     top_wg.align_wires(hm_layer, tr_manager, ytop_prev, ycur + blk_h, top_pcons=None)
 

--- a/src/xbase/layout/mos/placement/compact.py
+++ b/src/xbase/layout/mos/placement/compact.py
@@ -53,15 +53,18 @@ class RowPlaceSpecs:
     top_conn_y_table: ImmutableSortedDict[MOSWireType, Tuple[int, int]]
     bot_ext_info: RowExtInfo
     top_ext_info: RowExtInfo
+    mid_conn_y_table: Optional[ImmutableSortedDict[MOSWireType, Tuple[int, int]]]
 
     def __init__(self, row_specs: MOSRowSpecs, row_info: MOSRowInfo,
                  bot_conn_y_table: Mapping[MOSWireType, Tuple[int, int]],
                  top_conn_y_table: Mapping[MOSWireType, Tuple[int, int]],
-                 bot_ext_info: RowExtInfo, top_ext_info: RowExtInfo):
+                 bot_ext_info: RowExtInfo, top_ext_info: RowExtInfo,
+                 mid_conn_y_table: Optional[Mapping[MOSWireType, Tuple[int, int]]] = {}):
         # work around: this is how you set attributes for frozen data classes
         object.__setattr__(self, 'row_specs', row_specs)
         object.__setattr__(self, 'row_info', row_info)
         object.__setattr__(self, 'bot_conn_y_table', ImmutableSortedDict(bot_conn_y_table))
+        object.__setattr__(self, 'mid_conn_y_table', ImmutableSortedDict(mid_conn_y_table))
         object.__setattr__(self, 'top_conn_y_table', ImmutableSortedDict(top_conn_y_table))
         object.__setattr__(self, 'bot_ext_info', bot_ext_info)
         object.__setattr__(self, 'top_ext_info', top_ext_info)
@@ -88,6 +91,7 @@ class PlaceFun:
 
 def _get_row_place_specs(tcls: MOSTech, specs_list: Sequence[MOSRowSpecs],
                          global_options: Param) -> Sequence[RowPlaceSpecs]:
+    """For each MOSRowSpecs, construct MOSRowInfo and RowPlaceSpecs"""
     conn_layer = tcls.conn_layer
 
     num_rows = len(specs_list)
@@ -114,6 +118,11 @@ def _get_row_place_specs(tcls: MOSTech, specs_list: Sequence[MOSRowSpecs],
                             for wtype in row_info.bot_conn_types}
         top_conn_y_table = {wtype: row_info.get_conn_y(wtype)
                             for wtype in row_info.top_conn_types}
+        if specs.double_gate:
+            mid_conn_y_table = {wtype: row_info.get_conn_y(wtype)
+                                for wtype in row_info.mid_conn_types}
+        else:
+            mid_conn_y_table = {}
 
         if specs.flip:
             bext_info = row_info.top_ext_info
@@ -123,16 +132,17 @@ def _get_row_place_specs(tcls: MOSTech, specs_list: Sequence[MOSRowSpecs],
             text_info = row_info.top_ext_info
 
         info_list.append(RowPlaceSpecs(specs, row_info, bot_conn_y_table, top_conn_y_table,
-                                       bext_info, text_info))
+                                       bext_info, text_info, mid_conn_y_table=mid_conn_y_table))
 
     return info_list
 
 
 def _place_mirror(tech_cls: MOSTech, ext_info: RowExtInfo, ycur: int, ignore_vm_sp_le: bool = False
                   ) -> Tuple[int, int]:
+    """Extend the current extention such that it can be mirrored"""
     blk_h_pitch = tech_cls.blk_h_pitch
 
-    mirror_ext_w_info = tech_cls.get_ext_width_info(ext_info, ext_info,
+    mirror_ext_w_info: ExtWidthInfo = tech_cls.get_ext_width_info(ext_info, ext_info,
                                                     ignore_vm_sp_le=ignore_vm_sp_le)
 
     ext_w_cur = ycur // blk_h_pitch
@@ -146,6 +156,30 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
                 tot_height_min: int, tot_height_pitch: int, bot_mirror: bool, top_mirror: bool,
                 hm_shift: Union[int, HalfInt] = 0, max_iter: int = 100
                 ) -> Tuple[ImmutableList[RowPlaceInfo], List[Tuple[WireGraph, WireGraph]]]:
+    """Used by place_rows_compact to place rows after getting RowPlaceSpecs for all rows.
+
+    Parameters
+    ----------
+    tr_manager : TrackManager
+        the track manager of the MOSBase.
+    tech_cls : MOSTech
+        the technology specific class for drawing layout
+    pspecs_list : Sequence[RowPlaceSpecs]
+        list of RowPlaceSpecs. See _get_row_place_specs for construction details
+    tot_height_min: int
+        Minimum cell height, set by e.g. desired heigher metal tracks.
+    tot_height_pitch: int
+        Quantize the cell height to this dimension. Typically a tile height.
+    bot_mirror : bool
+        True to satisfy mirror placement constraint on the bottom edge.
+    top_mirror : bool
+        True to satisfy mirror placement constraint on the top edge.
+    hm_shift: Union[int, HalfInt]
+        Optional vertical track shift for the bottom (0th) row.
+    max_iter:
+        Maximum number of iterations to try to fix the cell bottom - active bottom extension
+            to fit the bottom tracks.
+    """
     grid = tr_manager.grid
     blk_h_pitch = tech_cls.blk_h_pitch
     conn_layer = tech_cls.conn_layer
@@ -160,13 +194,13 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
     pinfo_list = []
     prev_wg: Optional[WireGraph] = None
     row_graph_list: List[Tuple[WireGraph, WireGraph]] = []
-    # first pass: determine Y coordinates of each row.
+
     for idx, pspecs in enumerate(pspecs_list):
         bot_ext_info = pspecs.bot_ext_info
         top_ext_info = pspecs.top_ext_info
         bot_conn_y_table = pspecs.bot_conn_y_table
+        mid_conn_y_table = pspecs.mid_conn_y_table
         top_conn_y_table = pspecs.top_conn_y_table
-
         row_specs = pspecs.row_specs
         ignore_bot_vm_sp_le = row_specs.ignore_bot_vm_sp_le
         ignore_top_vm_sp_le = row_specs.ignore_top_vm_sp_le
@@ -174,9 +208,11 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
         row_info = pspecs.row_info
         blk_h = row_info.height
 
-        bot_wg = WireGraph.make_wire_graph(hm_layer, tr_manager, row_specs.bot_wires)
-        top_wg = WireGraph.make_wire_graph(hm_layer, tr_manager, row_specs.top_wires)
+        bot_wg: WireGraph = WireGraph.make_wire_graph(hm_layer, tr_manager, row_specs.bot_wires)
+        mid_wg: WireGraph = WireGraph.make_wire_graph(hm_layer, tr_manager, row_specs.mid_wires)
+        top_wg: WireGraph = WireGraph.make_wire_graph(hm_layer, tr_manager, row_specs.top_wires)
         row_graph_list.append((bot_wg, top_wg))
+
         if idx == 0:
             # first row, place bottom wires using mirror/shift constraints
             bot_wg.place_compact(hm_layer, tr_manager, bot_mirror=bot_mirror, shift=hm_shift)
@@ -184,7 +220,7 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
             # subsequent rows, place bottom wires using previous wire graph
             bot_wg.place_compact(hm_layer, tr_manager, prev_wg=prev_wg)
 
-        bnd_table = bot_wg.get_placement_bounds(hm_layer, grid)
+        bnd_table: Dict[str, List[Tuple[HalfInt, int]]] = bot_wg.get_placement_bounds(hm_layer, grid)
 
         # find Y coordinate of MOS row
         ycur = ytop_prev
@@ -254,32 +290,73 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
                                             conn_y_bnds_bot[0], False)
         conn_y_bnds_bot[1] = _update_y_conn(grid, row_info, conn_layer, ycur, bnd_table,
                                             conn_y_bnds_bot[1], True)
-        # place top wires
-        is_top_row = (idx == num_rows - 1)
-        conn_y_bnds_top = [COORD_MAX, COORD_MIN]
-        pcons = {}
-        for wtype, conn_y in top_conn_y_table.items():
-            pcons[wtype.name] = ycur + conn_y[0]
-            if wtype.is_physical:
-                conn_y_bnds_top[0] = min(conn_y_bnds_top[0], ycur + conn_y[0])
-                conn_y_bnds_top[1] = max(conn_y_bnds_top[1], ycur + conn_y[1])
-
         if bot_wg:
             prev_wg = bot_wg
-        if top_wg:
-            top_wg.place_compact(hm_layer, tr_manager,
-                                 pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
-                                 prev_wg=prev_wg, top_mirror=top_mirror and is_top_row,
-                                 ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_top[1]))
-            if row_info.row_type.is_substrate:
-                top_wg.align_wires(hm_layer, tr_manager, ytop_prev, ycur + blk_h, top_pcons=None)
 
-        # get ytop_conn
-        bnd_table = top_wg.get_placement_bounds(hm_layer, grid)
-        conn_y_bnds_top[0] = _update_y_conn(grid, row_info, conn_layer, ycur, bnd_table,
-                                            conn_y_bnds_top[0], False)
-        conn_y_bnds_top[1] = _update_y_conn(grid, row_info, conn_layer, ycur, bnd_table,
-                                            conn_y_bnds_top[1], True)
+        is_top_row = (idx == num_rows - 1)
+        if row_specs.double_gate:
+            # place middle wires
+            conn_y_bnds_mid = [COORD_MAX, COORD_MIN]
+            pcons = {}
+            for wtype, conn_y in mid_conn_y_table.items():
+                pcons[wtype.name] = ycur + conn_y[0]
+                if wtype.is_physical:
+                    conn_y_bnds_mid[0] = min(conn_y_bnds_mid[0], ycur + conn_y[0])
+                    conn_y_bnds_mid[1] = max(conn_y_bnds_mid[1], ycur + conn_y[1])
+
+            if mid_wg:
+                mid_wg.place_compact(hm_layer, tr_manager,
+                                    pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
+                                    prev_wg=prev_wg, #top_mirror=top_mirror and is_top_row,)
+                                    ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_mid[1]))
+                prev_wg = mid_wg
+            
+            # place top wires above the middle wires
+            conn_y_bnds_top = [COORD_MAX, COORD_MIN]
+            pcons = {}
+            for wtype, conn_y in top_conn_y_table.items():
+                pcons[wtype.name] = ycur + conn_y[0]
+                if wtype.is_physical:
+                    conn_y_bnds_top[0] = min(conn_y_bnds_top[0], ycur + conn_y[0])
+                    conn_y_bnds_top[1] = max(conn_y_bnds_top[1], ycur + conn_y[1])
+
+            if top_wg:
+                top_wg.place_compact(hm_layer, tr_manager,
+                                    pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
+                                    prev_wg=prev_wg, #top_mirror=top_mirror and is_top_row,
+                                    ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_top[1]))
+                prev_wg = top_wg
+            
+            bnd_table = top_wg.get_placement_bounds(hm_layer, grid)
+            conn_y_bnds_top[0] = _update_y_conn(grid, row_info, conn_layer, ycur, bnd_table,
+                                                conn_y_bnds_top[0], False)
+            conn_y_bnds_top[1] = _update_y_conn(grid, row_info, conn_layer, ycur, bnd_table,
+                                                conn_y_bnds_top[1], True)
+        else:
+            # place top wires
+            
+            conn_y_bnds_top = [COORD_MAX, COORD_MIN]
+            pcons = {}
+            for wtype, conn_y in top_conn_y_table.items():
+                pcons[wtype.name] = ycur + conn_y[0]
+                if wtype.is_physical:
+                    conn_y_bnds_top[0] = min(conn_y_bnds_top[0], ycur + conn_y[0])
+                    conn_y_bnds_top[1] = max(conn_y_bnds_top[1], ycur + conn_y[1])
+
+            if top_wg:
+                top_wg.place_compact(hm_layer, tr_manager,
+                                    pcons=PlaceFun(conn_layer, grid, pcons, RoundMode.GREATER_EQ),
+                                    prev_wg=prev_wg, top_mirror=top_mirror and is_top_row,
+                                    ytop_conn=max(conn_y_bnds_bot[1], conn_y_bnds_top[1]))
+                if row_info.row_type.is_substrate:
+                    top_wg.align_wires(hm_layer, tr_manager, ytop_prev, ycur + blk_h, top_pcons=None)
+
+            # get ytop_conn
+            bnd_table = top_wg.get_placement_bounds(hm_layer, grid)
+            conn_y_bnds_top[0] = _update_y_conn(grid, row_info, conn_layer, ycur, bnd_table,
+                                                conn_y_bnds_top[0], False)
+            conn_y_bnds_top[1] = _update_y_conn(grid, row_info, conn_layer, ycur, bnd_table,
+                                                conn_y_bnds_top[1], True)
 
         # compute ytop
         ytop_blk = ycur + blk_h
@@ -311,7 +388,8 @@ def _place_rows(tr_manager: TrackManager, tech_cls: MOSTech, pspecs_list: Sequen
         ybot_conn = min(conn_y_bnds_bot[0], conn_y_bnds_top[0])
         ytop_conn = max(conn_y_bnds_bot[1], conn_y_bnds_top[1])
         pinfo_list.append(RowPlaceInfo(row_info, bot_wg.get_wire_lookup(), top_wg.get_wire_lookup(),
-                                       ytop_prev, ytop, ycur, ytop_blk, (ybot_conn, ytop_conn)))
+                                       ytop_prev, ytop, ycur, ytop_blk, (ybot_conn, ytop_conn),
+                                       mid_wires=mid_wg.get_wire_lookup()))
 
         # update previous row information
         ytop_prev = ytop

--- a/src/xbase/layout/mos/placement/data.py
+++ b/src/xbase/layout/mos/placement/data.py
@@ -936,10 +936,19 @@ class TilePatternElement:
         rpinfo = pinfo.get_row_place_info(row_idx)
         if isinstance(wire_type, bool):
             top = wire_type
+            wlookup = rpinfo.top_wires if top else rpinfo.bot_wires
         else:
-            flip_row = rpinfo.row_info.flip
-            top = (wire_type.is_gate == flip_row)
-        wlookup = rpinfo.top_wires if top else rpinfo.bot_wires
+            if rpinfo.row_info.double_gate:
+                flip_row = rpinfo.row_info.flip
+                if not (wire_type.is_gate or wire_type.is_gate2):
+                    wlookup = rpinfo.mid_wires
+                else:
+                    top = (wire_type.is_gate == flip_row)
+                    wlookup = rpinfo.top_wires if top else rpinfo.bot_wires
+            else:
+                flip_row = rpinfo.row_info.flip
+                top = (wire_type.is_gate == flip_row)
+                wlookup = rpinfo.top_wires if top else rpinfo.bot_wires
 
         if flip_tile:
             return wlookup, yb + pinfo.height, -1

--- a/src/xbase/layout/mos/primitives.py
+++ b/src/xbase/layout/mos/primitives.py
@@ -99,6 +99,7 @@ class MOSConn(TemplateBase):
         draw_layout_in_template(self, mos_info.lay_info)
 
         g_conn_y = row_info.g_conn_y
+        g2_conn_y = row_info.g2_conn_y
         if g_on_s:
             if (stack & 1) == 0:
                 d_conn_y = row_info.ds_g_conn_y
@@ -121,12 +122,20 @@ class MOSConn(TemplateBase):
         d_tr_p = d_pitch // pitch
         s_tr_p = s_pitch // pitch
 
-        gw = self.add_wires(conn_layer, g_tr, g_conn_y[0], g_conn_y[1], num=num_g, pitch=g_tr_p)
         dw = self.add_wires(conn_layer, d_tr, d_conn_y[0], d_conn_y[1], num=num_d, pitch=d_tr_p)
         sw = self.add_wires(conn_layer, s_tr, s_conn_y[0], s_conn_y[1], num=num_s, pitch=s_tr_p)
-        self.add_pin('g', gw)
         self.add_pin('d', dw)
         self.add_pin('s', sw)
+
+        """Double gate options: draw_g enables drawing g. draw_g2 enables drawing g2. Defaults to drawing both"""
+        draw_g = options.get('draw_g', True)
+        draw_g2 = options.get('draw_g2', True)
+        if not row_info.double_gate or draw_g:
+            gw = self.add_wires(conn_layer, g_tr, g_conn_y[0], g_conn_y[1], num=num_g, pitch=g_tr_p)
+            self.add_pin('g', gw)
+        if row_info.double_gate and draw_g2:
+            g2w = self.add_wires(conn_layer, g_tr, g2_conn_y[0], g2_conn_y[1], num=num_g, pitch=g_tr_p)
+            self.add_pin('g2', g2w)
 
         if mos_info.m_info is not None:
             m_xc, num_m, m_pitch = mos_info.m_info

--- a/src/xbase/layout/mos/tech.py
+++ b/src/xbase/layout/mos/tech.py
@@ -130,6 +130,11 @@ class MOSTech(abc.ABC):
     def can_short_adj_tracks(self, conn_layer: int) -> bool:
         raise NotImplementedError('Not implemented')
 
+    @property
+    @abc.abstractmethod
+    def can_draw_double_gate(self) -> bool:
+        raise NotImplementedError('Not implemented')
+
     @abc.abstractmethod
     def get_track_specs(self, conn_layer: int, top_layer: int) -> List[TrackSpec]:
         return []

--- a/src/xbase_test/layout/mos/doublegate.py
+++ b/src/xbase_test/layout/mos/doublegate.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2019 Blue Cheetah Analog Design Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module shows an example of a double gate device."""
+
+from typing import Any, Dict, Optional, Type
+
+from bag.design.module import Module
+from bag.util.immutable import Param
+from bag.layout.template import TemplateDB
+
+from xbase.layout.enum import MOSWireType
+from xbase.layout.mos.data import MOSRowInfo
+from xbase.layout.mos.base import MOSBase, MOSBasePlaceInfo
+from xbase.layout.mos.top import MOSBaseWrapper
+
+from xbase.schematic.mos_char import xbase__mos_char
+
+
+class DoubleGateCore(MOSBase):
+    """An example layout of a double gate to show usage.
+    """
+
+    def __init__(self, temp_db: TemplateDB, params: Param, **kwargs: Any) -> None:
+        MOSBase.__init__(self, temp_db, params, **kwargs)
+
+    @classmethod
+    def get_schematic_class(cls) -> Optional[Type[Module]]:
+        return xbase__mos_char
+
+    @classmethod
+    def get_params_info(cls) -> Dict[str, str]:
+        return dict(
+            pinfo='The MOSBasePlaceInfo object.',
+            w='transistor width.',
+            seg='number of segments.',
+            g_on_s='True to draw gate on source',
+        )
+
+    @classmethod
+    def get_default_param_values(cls) -> Dict[str, Any]:
+        return dict(g_on_s=False)
+
+    def draw_layout(self):
+        seg: int = self.params['seg']
+        w: int = self.params['w']
+        g_on_s: bool = self.params['g_on_s']
+
+        pinfo = MOSBasePlaceInfo.make_place_info(self.grid, self.params['pinfo'])
+        self.draw_base(pinfo)
+
+        dev_row = 1
+        rinfo: MOSRowInfo = self.get_row_info(dev_row)
+        lch = rinfo.lch
+        mos_type_str = rinfo.row_type.name
+        intent = rinfo.threshold
+
+        if not rinfo.double_gate:
+            raise ValueError("double_gate is not set to True in pinfo")
+
+        # Optional flags draw_g and draw_g2 set which gate connections to draw.
+        ports = self.add_mos(row_idx=dev_row, col_idx=0, seg=seg, g_on_s=g_on_s, sep_g=False,
+                             w=w, draw_g=True, draw_g2=True)
+        b_bot = self.add_substrate_contact(0, 0, seg=seg)
+        b_top = self.add_substrate_contact(2, 0, seg=seg)
+
+        self.set_mos_size()
+
+        g = ports.g
+        g2 = ports.g2
+        s = ports.s
+        d = ports.d
+
+        g_tid = self.get_track_id(dev_row, MOSWireType.G, 'sig')
+        g2_tid = self.get_track_id(dev_row, MOSWireType.G2, 'sig')
+        d_tid = self.get_track_id(dev_row, MOSWireType.DS, 'sig', 0)
+        s_tid = self.get_track_id(dev_row, MOSWireType.DS, 'sig', -1)
+        
+        b_tid0 = self.get_track_id(0, MOSWireType.DS, 'b')
+        b_tid1 = self.get_track_id(2, MOSWireType.DS, 'b')
+
+        b0 = self.connect_to_tracks(b_bot, b_tid0)
+        b1 = self.connect_to_tracks(b_top, b_tid1)
+
+        g_hm = self.connect_to_tracks(g, g_tid)
+        g2_hm = self.connect_to_tracks(g2, g2_tid)
+
+        s_hm = self.connect_to_tracks(s, s_tid)
+        d_hm = self.connect_to_tracks(d, d_tid)
+
+        
+        self.add_pin('g', [g_hm, g2_hm], connect=True)
+        self.add_pin('s', s_hm)
+        self.add_pin('d', d_hm)
+        self.add_pin('b', [b0, b1], connect=True)
+
+        self.sch_params = dict(
+            mos_type=mos_type_str,
+            w=w,
+            lch=lch,
+            seg=seg,
+            intent=intent,
+            dum_info=[],
+        )


### PR DESCRIPTION
Features (and documentation) for double gate
- Modified MOSWireType to include G2, the double gate
- Added check in MOSBase and in MOSTech for if double_gate is implemented
- Modified MOSPorts to include optional G2
- Modified MOSRowSpecs to include mid_conn_info when there is double gate
- Modified MOSRowInfo to include g2_conn when there is double gate
- Modified wire placement strategy to include double gate
- Modified wire lookup to look for middle wires
- Modified MOSConn primitive to include a g2 pin
- Add an example layout class of a single double gate transistor